### PR TITLE
Fix psgql table qouting

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -238,6 +238,7 @@ class Connection
             case 'mssql':
             case 'sybase':
                 $quote = '"';
+                break;
             case 'mysql':
             case 'sqlite':
             case 'sqlite2':


### PR DESCRIPTION
Without this fix it uses ` instead of `"` which causes:

```
PDOException: SQLSTATE[42601]: Syntax error: 7 ERROR: syntax error at or near "`" LINE 2: FROM `priest` ^ in C:\wamp\www\lib\third party\ArkDatabase\QueryBuilder.php on line 549
```
